### PR TITLE
Fixed $srcdir always being .

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,8 +95,8 @@ AC_MSG_NOTICE([notice prefix: ${prefix}])
 
 AC_MSG_NOTICE([Using bundled jalson])
 internal_jalson=1
-jalsoninc="$srcdir/jalson/src"
-jalsonlib="../jalson/src"
+jalsoninc="$(realpath $srcdir)/jalson/src"
+jalsonlib="$(realpath $srcdir)/jalson/src"
 AC_SUBST(jalsoninc)
 AC_SUBST(jalsonlib)
 


### PR DESCRIPTION
$srcdir was always showing . from withing jalson sub-project so `wampcc/json.h` and `wampcc/json_internals.h`.

This was due to `jalsoninc` being replaced with `-I./jalson/src` instead of `-I../jalson/src`.
There probably is a better solution then this but it's a safe one even for external jalson sources as it uses an absolute path to the include folder.

`Build and tested on linuxmint 18.1`