### PR TITLE
Check for valid m_notify_state_change_fn during session shutdown

### DIFF
--- a/libs/wampcc/wamp_session.cc
+++ b/libs/wampcc/wamp_session.cc
@@ -2199,7 +2199,8 @@ void wamp_session::transition_to_closed()
   // would be a programming error.
 
   try {
-    m_notify_state_change_fn(*this, false);
+    if (m_notify_state_change_fn)
+      m_notify_state_change_fn(*this, false);
   }
   catch (...) {
     /* ignore */


### PR DESCRIPTION
… to avoid crash in case that this callback has not been set.