### PR TITLE
On Windows, allow compilation with WIN32_LEAN_AND_MEAN

### DIFF
--- a/libs/wampcc/platform.cc
+++ b/libs/wampcc/platform.cc
@@ -18,6 +18,9 @@
 #include <sys/utsname.h>
 #else
 #include <Windows.h>
+#ifdef WIN32_LEAN_AND_MEAN
+#include <Winsock2.h> /* For gethostname */
+#endif
 #endif
 
 namespace wampcc


### PR DESCRIPTION
On Windows, if WIN32_LEAN_AND_MEAN is defined, Winsock2.h is not included via Windows.h but has to be included explicitely.