### PR TITLE
Added automatic ECDH selection to ssl context

### DIFF
--- a/libs/wampcc/ssl.cc
+++ b/libs/wampcc/ssl.cc
@@ -65,6 +65,10 @@ ssl_context::ssl_context(logger & l,
 
   /* Recommended to avoid SSLv2 & SSLv3 */
   SSL_CTX_set_options(m_ctx, SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+
+  /* Enable automatic ECDH selection */
+  if(SSL_CTX_set_ecdh_auto(m_ctx, 1) != 1)
+      throw_ssl_error("SSL_CTX_set_ecdh_auto");
 }
 
 


### PR DESCRIPTION
With default setup Windows enables only ephemeral versions of the elliptic curve cipher suites. 
https://msdn.microsoft.com/en-us/library/windows/desktop/mt767769(v=vs.85).aspx . With current ssl context configuration this causes ssl handshake failure if such suite is used.

Proposed modification enables automatic selection of appropriate curve 
https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_ecdh_auto.html

It should be noted that modification requires openssl 1.0.2 or above.
