### PR TITLE
Added args.list and args.dict  when returning caller error from router

### DIFF
--- a/libs/wampcc/wamp_router.cc
+++ b/libs/wampcc/wamp_router.cc
@@ -165,7 +165,7 @@ void wamp_router::handle_inbound_call(
                 if (info)
                   caller->result(caller_request_id, info.args.args_list, info.args.args_dict);
                 else
-                  caller->call_error(caller_request_id, info.error_uri);
+                  caller->call_error(caller_request_id, info.error_uri, info.args.args_list, info.args.args_dict);
               }
             };
 


### PR DESCRIPTION
Change enables passing application specific objects on invocation_error to caller.

Per https://github.com/wamp-proto/wamp-proto/blob/master/rfc/text/basic/bp_rpc_calling_and_invocation.md invocation_error shall pass to caller

Arguments, a.k.a args_list
ArgumentsKw, a.k.a args_dict

