### PR TITLE
Added option to use external ssl context configuration

### DIFF
--- a/include/wampcc/kernel.h
+++ b/include/wampcc/kernel.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <mutex>
 #include <functional>
+#include <openssl/ssl.h>
 
 namespace wampcc
 {
@@ -94,7 +95,6 @@ struct logger
   static logger nolog();
 };
 
-
 struct ssl_config
 {
   /* Must be set to true to indicate SSL should be set up. */
@@ -105,9 +105,11 @@ struct ssl_config
   std::string certificate_file;
   std::string private_key_file;
 
-  ssl_config(bool use_ssl_) : enable(use_ssl_) {}
-};
+  /* optional custom SSL context creator */
+  std::function<SSL_CTX *(const struct ssl_config &ssl_config)> custom_ctx_creator;
 
+  ssl_config(bool use_ssl_) : enable(use_ssl_), custom_ctx_creator(nullptr) {}
+};
 
 struct config
 {

--- a/libs/wampcc/CMakeLists.txt
+++ b/libs/wampcc/CMakeLists.txt
@@ -19,7 +19,8 @@ set(INSTALL_HDRS
   ${PROJECT_SOURCE_DIR}/include/wampcc/error.h
   ${PROJECT_SOURCE_DIR}/include/wampcc/helper.h
   ${PROJECT_SOURCE_DIR}/include/wampcc/wampcc.h
-  ${PROJECT_SOURCE_DIR}/include/wampcc/ssl_socket.h)
+  ${PROJECT_SOURCE_DIR}/include/wampcc/ssl_socket.h
+        )
 
 ##
 ## Static library


### PR DESCRIPTION
Pullrequest is related to https://github.com/darrenjs/wampcc/issues/25 
After some consideration for different approach, I fould this, completeley externalised ssl context creation to be the easiest from library maintenance point of view. No assumptions or complex logic about the context needed.