### PR TITLE
Fix compatibility with OpenSSL 1.1

### DIFF
--- a/libs/wampcc/utils.cc
+++ b/libs/wampcc/utils.cc
@@ -31,10 +31,6 @@ int compute_HMACSHA256(const char* key, int keylen, const char* msg, int msglen,
 
   int retval = -1; /* success=0, fail=-1 */
 
-  /* initialise HMAC context */
-  HMAC_CTX ctx;
-  HMAC_CTX_init(&ctx);
-
   unsigned char md[EVP_MAX_MD_SIZE + 1]; // EVP_MAX_MD_SIZE=64
   memset(md, 0, sizeof(md));
   unsigned int mdlen;
@@ -153,9 +149,6 @@ int compute_HMACSHA256(const char* key, int keylen, const char* msg, int msglen,
       *destlen = j + 1;
     }
   }
-
-  /* cleanup HMAC */
-  HMAC_CTX_cleanup(&ctx);
 
   return retval;
 }


### PR DESCRIPTION
OpenSSL 1.1 removed the deprecated HMAC_CTX_init() and
HMAC_CTX_cleanup() and declared the HMAC_CTX struct private.

However, as far as I can see HMAC_CTX isn't used at all here,
so the problematic code can simply be removed