### PR TITLE
Feature Request: Add support for retained messages.

### DIFF
--- a/include/wampcc/wamp_session.h
+++ b/include/wampcc/wamp_session.h
@@ -28,6 +28,8 @@ class kernel;
 class pubsub_man;
 struct logger;
 
+/** Option key for enabling publishing of retained messages. */
+constexpr const char* KEY_RETAINED = "_retained";
 
 /** Callback type used to provide a session ID for new sessions. */
 typedef std::function<t_session_id()> session_id_generator_fn;


### PR DESCRIPTION
MQTT has a concept of retained messages (https://www.hivemq.com/blog/mqtt-essentials-part-8-retained-messages). It might be useful to have something similar in wampcc. 