### PR TITLE
Fixed missing -lwampcc ldflag

### DIFF
--- a/cmake/wampcc.pc.incmake
+++ b/cmake/wampcc.pc.incmake
@@ -9,5 +9,5 @@ Description: WAMP C++ library
 Version: @WAMPCC_VERSION@
 
 Requires:
-Libs: -L${libdir} -L${sharedlibdir} -luv -lcrypto -lssl -lpthread -lwampcc_json
+Libs: -L${libdir} -L${sharedlibdir} -lwampcc -luv -lcrypto -lssl -lpthread -lwampcc_json
 Cflags: -I${includedir}


### PR DESCRIPTION
Using pkg-config to pull in required compile parameters does not work as -lwampcc is missing in the list