### PR TITLE
Authorization

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,7 +38,9 @@ if(BUILD_EXAMPLES)
   Compile_Example(demo_embedded_router basic)
   Compile_Example(basic_server basic)
 # Authentication
-  Compile_Example(authentication_router authentication)
+  Compile_Example(basic_authentication_provider authentication)
+# Authorization
+  Compile_Example(basic_authorization_provider authorization)
 # Message server
   Compile_Example(message_server message_server)
   Compile_Example(message_subscriber message_server)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,6 +37,8 @@ if(BUILD_EXAMPLES)
   Compile_Example(demo_embedded_router_ssl basic)
   Compile_Example(demo_embedded_router basic)
   Compile_Example(basic_server basic)
+# Authentication
+  Compile_Example(authentication_router authentication)
 # Message server
   Compile_Example(message_server message_server)
   Compile_Example(message_subscriber message_server)

--- a/examples/authentication/authentication_router.cc
+++ b/examples/authentication/authentication_router.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2017 Darren Smith
+ *
+ * wampcc is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include "wampcc/wampcc.h"
+
+#include <iostream>
+
+using namespace wampcc;
+using namespace std;
+
+int main(int, char**)
+{
+  try {
+    /* Create the wampcc kernel. */
+
+    kernel the_kernel;
+
+    /* Create an embedded wamp router. */
+
+    wamp_router router(&the_kernel);
+
+    /* Accept clients on IPv4 port, without authentication. */
+
+    auth_provider auth = {
+      // provider_name
+      [](const std::string& realm) { 
+        return "example_auth"; 
+      },
+      // policy
+      [](const std::string& user, const std::string& realm) {
+        if(realm == "default_realm")
+          return auth_provider::auth_plan{ auth_provider::mode::open, {} };
+        else if(realm == "private_realm")
+          return auth_provider::auth_plan(auth_provider::mode::authenticate, {"wampcra"});
+        else
+          return auth_provider::auth_plan(auth_provider::mode::forbidden, {});
+      },
+      // cra_salt
+      nullptr, 
+      // check_cra
+      nullptr, 
+      // user_secret
+      [](const std::string& /*user*/, const std::string& /*realm*/) {
+        return "secret2"; 
+      },
+      // user_role
+      [](const std::string& /*user*/, const std::string& realm) {
+        std::cout << "user_role()\n";
+        if(realm == "private_realm")
+          return "frontend";
+        else
+          return "anonymous";
+      },
+      // authorize
+      [](const std::string& realm, const std::string& authrole, const std::string& uri, auth_provider::action) {
+        //return false;
+        throw runtime_error("some error");
+        return false;
+      }
+    };
+
+  /*static auth_provider no_auth_required() {
+    return auth_provider {
+      [](const std::string&){ return "no_auth_required"; },
+        [](const std::string&, const std::string&) {
+          return auth_plan{mode::open,{}}; },
+          nullptr, nullptr, nullptr };
+  }*/
+
+    auto fut = router.listen(auth, 55555);
+
+    if (auto ec = fut.get())
+      throw runtime_error(ec.message());
+
+    /* Provide an RPC named 'greeting' on realm 'default_realm'. */
+
+    router.callable("default_realm", "greeting",
+                    [](wamp_router&, wamp_session& caller, call_info info) {
+      caller.result(info.request_id, {"hello"});
+    });
+
+    router.callable("private_realm", "greeting",
+                    [](wamp_router&, wamp_session& caller, call_info info) {
+      caller.result(info.request_id, {"hello private member ;)"});
+    });
+
+    /* Suspend main thread */
+    std::promise<void> forever;
+    forever.get_future().wait();
+  } catch (const exception& e) {
+    cout << e.what() << endl;
+    return 1;
+  }
+}

--- a/examples/authentication/basic_authentication_provider.cc
+++ b/examples/authentication/basic_authentication_provider.cc
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017 Darren Smith
+ * Copyright (c) 2018 Daniel Kesler
+ *
+ * wampcc is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include "wampcc/wampcc.h"
+
+#include <iostream>
+
+using namespace wampcc;
+using namespace std;
+
+int main(int, char**)
+{
+  try {
+    /* Create the wampcc kernel. */
+
+    kernel the_kernel;
+
+    /* Create an embedded wamp router. */
+
+    wamp_router router(&the_kernel);
+
+    /* Accept clients on IPv4 port, without authentication. */
+
+    auth_provider auth = {
+      // provider_name
+      [](const std::string& realm) { 
+        return "example_auth"; 
+      },
+      // policy
+      [](const std::string& user, const std::string& realm) {
+        if(realm == "default_realm")
+          return auth_provider::auth_plan{ auth_provider::mode::open, {} };
+        else if(realm == "private_realm")
+          return auth_provider::auth_plan(auth_provider::mode::authenticate, {"wampcra"});
+        else
+          return auth_provider::auth_plan(auth_provider::mode::forbidden, {});
+      },
+      // cra_salt
+      nullptr, 
+      // check_cra
+      nullptr, 
+      // user_secret
+      [](const std::string& /*user*/, const std::string& /*realm*/) {
+        return "secret2"; 
+      },
+    };
+
+    auto fut = router.listen(auth, 55555);
+
+    if (auto ec = fut.get())
+      throw runtime_error(ec.message());
+
+    /* Provide an RPC named 'greeting' on realm 'default_realm'. */
+
+    router.callable("default_realm", "greeting",
+                    [](wamp_router&, wamp_session& caller, call_info info) {
+      caller.result(info.request_id, {"hello"});
+    });
+
+    router.callable("private_realm", "greeting",
+                    [](wamp_router&, wamp_session& caller, call_info info) {
+      caller.result(info.request_id, {"hello private member"});
+    });
+
+    /* Suspend main thread */
+    std::promise<void> forever;
+    forever.get_future().wait();
+  } catch (const exception& e) {
+    cout << e.what() << endl;
+    return 1;
+  }
+}

--- a/include/wampcc/types.h
+++ b/include/wampcc/types.h
@@ -51,6 +51,7 @@ namespace wampcc
 // WAMP string constants
 #define WAMP_WAMPCRA "wampcra"
 #define WAMP_ACKNOWLEDGE "acknowledge"
+#define WAMP_ANONYMOUS "anonymous"
 
 // Protocol defined services
 #define WAMP_REFLECTION_TOPIC_LIST "wamp.reflection.topic.list"

--- a/include/wampcc/types.h
+++ b/include/wampcc/types.h
@@ -20,6 +20,7 @@ namespace wampcc
 {
 
 // WAMP defined error messages
+#define WAMP_ERROR_AUTHENTICATION_FAILED "wamp.error.authentication_failed"
 #define WAMP_ERROR_AUTHORIZATION_FAILED "wamp.error.authorization_failed"
 #define WAMP_ERROR_CANCELED "wamp.error.canceled"
 #define WAMP_ERROR_CLOSE_REALM "wamp.error.close_realm"

--- a/libs/wampcc/wamp_router.cc
+++ b/libs/wampcc/wamp_router.cc
@@ -264,12 +264,14 @@ std::future<uverr> wamp_router::listen(auth_provider auth,
                               json_object& details,
                               wamp_args& args)
     {
+      ws.authorize(uri, auth_provider::action::call);
       this->handle_inbound_call(&ws, reqid, uri, details, args);
     };
 
     handlers.on_publish =
     [this](wamp_session& ws, t_request_id request_id, std::string uri,
            json_object options, wamp_args args) {
+      ws.authorize(uri, auth_provider::action::publish);
       try {
         json_value* ptr = json_get_ptr(options, WAMP_ACKNOWLEDGE);
         bool acknowledge = ptr && ptr->is_true();
@@ -288,6 +290,7 @@ std::future<uverr> wamp_router::listen(auth_provider auth,
     handlers.on_subscribe =
         [this](wamp_session& ws, t_request_id request_id, std::string uri,
                json_object& options) {
+      ws.authorize(uri, auth_provider::action::subscribe);
       return this->m_pubsub->subscribe(&ws, request_id, uri, options);
     };
 
@@ -300,6 +303,7 @@ std::future<uverr> wamp_router::listen(auth_provider auth,
                                   t_request_id request_id,
                                   std::string& uri,
                                   json_object& options) -> void {
+      ws.authorize(uri, auth_provider::action::register1);
       m_rpcman->handle_inbound_register(ws, request_id, uri);
     };
 

--- a/libs/wampcc/wamp_session.cc
+++ b/libs/wampcc/wamp_session.cc
@@ -817,18 +817,19 @@ void wamp_session::handle_HELLO(json_array& ja)
       m_agent.second = agent;
     }
 
-    std::string authrole = "anonymous";
+    std::string authrole = WAMP_ANONYMOUS;
 
     if (m_auth_proivder.user_role and m_authid.first) {
-      std::string authrole = m_auth_proivder.user_role(m_authid.second, m_realm);
+      authrole = m_auth_proivder.user_role(m_authid.second, m_realm);
       if(authrole.empty())
         throw auth_error(WAMP_ERROR_NO_SUCH_ROLE, "role not configured");
     }
 
     {
       std::lock_guard<std::mutex> guard(m_authrole_lock);
-      if(m_authrole.empty())
+      if(m_authrole.empty()) {
         m_authrole = authrole;
+      }
     }
 
 

--- a/libs/wampcc/wamp_session.cc
+++ b/libs/wampcc/wamp_session.cc
@@ -817,6 +817,21 @@ void wamp_session::handle_HELLO(json_array& ja)
       m_agent.second = agent;
     }
 
+    std::string authrole = "anonymous";
+
+    if (m_auth_proivder.user_role and m_authid.first) {
+      std::string authrole = m_auth_proivder.user_role(m_authid.second, m_realm);
+      if(authrole.empty())
+        throw auth_error(WAMP_ERROR_NO_SUCH_ROLE, "role not configured");
+    }
+
+    {
+      std::lock_guard<std::mutex> guard(m_authrole_lock);
+      if(m_authrole.empty())
+        m_authrole = authrole;
+    }
+
+
   }
 
   auth_provider::mode auth_required;
@@ -832,7 +847,7 @@ void wamp_session::handle_HELLO(json_array& ja)
   else if (auth_required != auth_provider::mode::authenticate)
   {
     if (auth_required == auth_provider::mode::forbidden)
-      throw auth_error(WAMP_ERROR_AUTHORIZATION_FAILED,
+      throw auth_error(WAMP_ERROR_AUTHENTICATION_FAILED,
                        "auth_provider rejected user for realm");
   }
 
@@ -858,12 +873,12 @@ void wamp_session::handle_HELLO(json_array& ja)
 
   /* Handle case of no supported authentication methods */
   if (intersect.empty())
-    throw auth_error(WAMP_ERROR_AUTHORIZATION_FAILED,
+    throw auth_error(WAMP_ERROR_AUTHENTICATION_FAILED,
                      "no auth methods available");
 
   /* For now the only supported method is 'wampcra'. */
   if (intersect.find(WAMP_WAMPCRA) == intersect.end())
-    throw auth_error(WAMP_ERROR_AUTHORIZATION_FAILED,
+    throw auth_error(WAMP_ERROR_AUTHENTICATION_FAILED,
                      "wampcra not available for both client and server");
 
   /* --- Perform wampcra authentication --- */
@@ -883,7 +898,7 @@ void wamp_session::handle_HELLO(json_array& ja)
     if (m_challenge.empty())
       m_challenge = challengestr;
     else
-      throw auth_error(WAMP_ERROR_AUTHORIZATION_FAILED,
+      throw auth_error(WAMP_ERROR_AUTHENTICATION_FAILED,
                        "challenge already issued");
   }
 
@@ -921,13 +936,13 @@ void wamp_session::handle_CHALLENGE(json_array& ja)
 
   const std::string& authmethod = ja[1].as_string();
   if (authmethod != WAMP_WAMPCRA)
-    throw auth_error(WAMP_ERROR_AUTHORIZATION_FAILED,
+    throw auth_error(WAMP_ERROR_AUTHENTICATION_FAILED,
                      "unknown AuthMethod (only wampcra supported)");
 
   const json_object & extra = ja[2].as_object();
   std::string challmsg = json_get_copy(extra, "challenge", "").as_string();
   if (challmsg == "")
-    throw auth_error(WAMP_ERROR_AUTHORIZATION_FAILED,
+    throw auth_error(WAMP_ERROR_AUTHENTICATION_FAILED,
                      "challenge not found in Extra");
 
   /* generate the authentication digest */
@@ -969,7 +984,7 @@ void wamp_session::handle_CHALLENGE(json_array& ja)
     send_msg(msg);
   }
   else
-    throw auth_error(WAMP_ERROR_AUTHORIZATION_FAILED,
+    throw auth_error(WAMP_ERROR_AUTHENTICATION_FAILED,
                      "failed to compute HMAC SHA256 diget");
 
 }
@@ -1010,7 +1025,7 @@ void wamp_session::handle_AUTHENTICATE(json_array& ja)
                               digest, &digestlen);
     for (size_t i = 0; i < key.size(); i++) key[i]='\0';
     if (r == -1)
-      throw auth_error(WAMP_ERROR_AUTHORIZATION_FAILED,
+      throw auth_error(WAMP_ERROR_AUTHENTICATION_FAILED,
                        "HMAC SHA256 failed");
 
     cra_ok = (digest == peer_digest);
@@ -1019,7 +1034,7 @@ void wamp_session::handle_AUTHENTICATE(json_array& ja)
   if (cra_ok)
     send_WELCOME();
   else
-    throw auth_error(WAMP_ERROR_AUTHORIZATION_FAILED,
+    throw auth_error(WAMP_ERROR_AUTHENTICATION_FAILED,
                      "client failed challenge-response-authentication");
 }
 
@@ -2707,6 +2722,28 @@ bool wamp_session::has_authid() const
   return m_authid.first;
 }
 
+std::string wamp_session::authrole() const
+{
+  std::lock_guard<std::mutex> guard(m_authrole_lock);
+  return m_authrole;
+}
+
+void wamp_session::authorize(const std::string& uri, auth_provider::action action)
+{
+  if(m_auth_proivder.authorize) {
+    std::lock_guard<std::mutex> guard(m_authrole_lock);
+    bool authorized = false;
+    try {
+      authorized = m_auth_proivder.authorize(m_realm, m_authrole, uri, action);
+    } catch(...) {
+      throw wamp_error(WAMP_ERROR_AUTHORIZATION_FAILED, "authorization failure");
+    }
+
+    if( !authorized ) {
+      throw wamp_error(WAMP_ERROR_NOT_AUTHORIZED, "action is not authorized");
+    }
+  }
+}
 
 std::string wamp_session::agent() const
 {


### PR DESCRIPTION
- Added support for `authrole` in wamp_session as it is described in [crossbar.io/authorization](https://crossbar.io/docs/Authorization/)
- Added support for `user_role` and `authorize` functions in `auth_provider`. It is possible now to implement authorization in `auth_provider` as it is done in [crossbar.io/authorization](https://crossbar.io/docs/Authorization/)
- Added support for `authorize` in `wamp_session` and `wamp_router` which throws a wamp_error exception with `WAMP_ERROR_NOT_AUTHORIZED` in case the `uri`, `action` is not authorized for that particular session
- Added examples for custom `authentication` and `authorization`
- Fixed wrong use of `WAMP_ERROR_AUTHORIZATION_FAILED` when it should be `WAMP_ERROR_AUTHENTICATION_FAILED`