### PR TITLE
Add callbacks and improve WAMP error handling

### DIFF
--- a/examples/authorization/basic_authorization_provider.cc
+++ b/examples/authorization/basic_authorization_provider.cc
@@ -69,7 +69,7 @@ int main(int, char**)
         return role;
       },
       // authorize
-      [](const std::string& realm, const std::string& authrole, const std::string& uri, auth_provider::action) {
+      [](const wampcc::t_session_id& id, const std::string& realm, const std::string& authrole, const std::string& uri, auth_provider::action) {
         auth_provider::authorized authorized;
         authorized.allow = false;
         authorized.disclose = auth_provider::disclosure::optional;

--- a/examples/authorization/disclose_authorization_provider.cc
+++ b/examples/authorization/disclose_authorization_provider.cc
@@ -69,7 +69,7 @@ int main(int, char**)
         return role;
       },
       // authorize
-      [](const std::string& realm, const std::string& authrole, const std::string& uri, auth_provider::action) {
+      [](const wampcc::t_session_id& session_id, const std::string& realm, const std::string& authrole, const std::string& uri, auth_provider::action) {
         auth_provider::authorized authorized;
         authorized.allow = true;
         authorized.disclose = auth_provider::disclosure::optional;

--- a/include/wampcc/rpc_man.h
+++ b/include/wampcc/rpc_man.h
@@ -34,6 +34,7 @@ struct rpc_details
   uint64_t registration_id; // 0 implies invalid
   std::string uri;
   session_handle session;
+  json_object options;
   on_call_fn user_cb; // applies only for eInternal
   void* user;         // applies only for eInternal
   rpc_details() : registration_id(0), user(nullptr) {}
@@ -46,7 +47,7 @@ class rpc_man
 public:
   rpc_man(kernel*, rpc_added_cb);
 
-  void handle_inbound_register(wamp_session&, t_request_id, const std::string&);
+  void handle_inbound_register(wamp_session&, t_request_id, const std::string&, const json_object& options);
 
   void handle_inbound_unregister(wamp_session&, t_request_id,
                                  t_registration_id);

--- a/include/wampcc/rpc_man.h
+++ b/include/wampcc/rpc_man.h
@@ -27,20 +27,6 @@ class event_loop;
 struct logger;
 class kernel;
 
-struct rpc_details
-{
-  enum { eInternal, eRemote } type;
-
-  uint64_t registration_id; // 0 implies invalid
-  std::string uri;
-  std::string realm;
-  session_handle session;
-  json_object options;
-  on_call_fn user_cb; // applies only for eInternal
-  void* user;         // applies only for eInternal
-  rpc_details() : registration_id(0), user(nullptr) {}
-};
-
 typedef std::function<void(const rpc_details&)> rpc_added_cb;
 typedef std::function<void(const rpc_details&)> rpc_removed_cb;
 

--- a/include/wampcc/rpc_man.h
+++ b/include/wampcc/rpc_man.h
@@ -41,11 +41,12 @@ struct rpc_details
 };
 
 typedef std::function<void(const rpc_details&)> rpc_added_cb;
+typedef std::function<void(const rpc_details&)> rpc_removed_cb;
 
 class rpc_man
 {
 public:
-  rpc_man(kernel*, rpc_added_cb);
+  rpc_man(kernel*, rpc_added_cb, rpc_removed_cb);
 
   void handle_inbound_register(wamp_session&, t_request_id, const std::string&, const json_object& options);
 
@@ -71,6 +72,7 @@ private:
 
   logger& __logger; /* name chosen for log macros */
   rpc_added_cb m_rpc_added_cb;
+  rpc_removed_cb m_rpc_removed_cb;
 
   mutable std::mutex m_rpc_map_lock;
 

--- a/include/wampcc/rpc_man.h
+++ b/include/wampcc/rpc_man.h
@@ -33,6 +33,7 @@ struct rpc_details
 
   uint64_t registration_id; // 0 implies invalid
   std::string uri;
+  std::string realm;
   session_handle session;
   json_object options;
   on_call_fn user_cb; // applies only for eInternal

--- a/include/wampcc/tcp_socket.h
+++ b/include/wampcc/tcp_socket.h
@@ -105,9 +105,13 @@ class tcp_socket
 {
 public:
   enum class addr_family {
+    /** listen on both IPv6/IPv4, and
+     * connect to either IPv6 or IPv4  **/
     unspec,
+    /** IPv4 only **/
     inet4,
-    inet6,
+    /** IPv6 only **/
+    inet6
   };
 
   /** Type thrown by tcp_socket when actions are attempted when the socket is

--- a/include/wampcc/types.h
+++ b/include/wampcc/types.h
@@ -42,6 +42,8 @@ namespace wampcc
 #define WAMP_ERROR_PROCEDURE_ALREADY_EXISTS "wamp.error.procedure_already_exists"
 #define WAMP_ERROR_SYSTEM_SHUTDOWN "wamp.error.system_shutdown"
 
+#define WAMP_ERROR_REASON_KEY "_reason"
+
 // protocol extensions
 #define WAMP_RUNTIME_ERROR "wamp.error.runtime_error"
 #define WAMP_ERROR_BAD_PROTOCOL "wamp.error.bad_protocol"

--- a/include/wampcc/wamp_router.h
+++ b/include/wampcc/wamp_router.h
@@ -25,10 +25,18 @@ class rpc_man;
 class wamp_router;
 struct rpc_details;
 
-/* Callback type invoked when a wamp_router has been provided with a new RPC. */
+/** Callback type invoked when a wamp_router has been provided with a new RPC. **/
+typedef std::function<void(const rpc_details&)> on_rpc_registered;
 
-typedef std::function<void(std::string, json_object)> on_rpc_registered;
-typedef std::function<void(std::string)> on_rpc_unregistered;
+/** Callback type invoked when an RPC is being unregistered from a wamp_router. **/
+typedef std::function<void(const rpc_details&)> on_rpc_unregistered;
+
+/** Callback type invoked when the state of a session is changed in a wamp_router.
+ *
+ *  @todo Is passing wamp_session& to outside safe? Possiblity of deadlock if the outside
+ *  function calls wamp_session::uniqueid or authid.
+**/
+typedef std::function<void(wamp_session&, bool)> on_session_state_change;
 
 /** Aggregate representing the details of a CALL request that has arrived at the
  * router and is to be handled via callback of user code. */
@@ -97,8 +105,8 @@ public:
     {}
   };
 
+  wamp_router(kernel* __svc, on_rpc_registered = nullptr, on_rpc_unregistered = nullptr, on_session_state_change=nullptr);
   ~wamp_router();
-  wamp_router(kernel* __svc, on_rpc_registered = nullptr, on_rpc_unregistered = nullptr);
 
   /** Request asynchronous close */
   //  std::future<void> close();
@@ -156,6 +164,7 @@ private:
 
   on_rpc_registered m_on_rpc_registered;
   on_rpc_unregistered m_on_rpc_unregistered;
+  on_session_state_change m_on_session_state_change;
 
   std::mutex m_server_sockets_lock;
   std::vector<std::unique_ptr<tcp_socket>> m_server_sockets;

--- a/include/wampcc/wamp_router.h
+++ b/include/wampcc/wamp_router.h
@@ -43,6 +43,21 @@ struct call_info
 typedef std::function<void(wamp_router&,
                            wamp_session&,
                            call_info)> on_call_fn;
+struct rpc_details
+{
+  enum { eInternal, eRemote } type;
+
+  uint64_t registration_id; // 0 implies invalid
+  std::string uri;
+  std::string realm;
+  session_handle session;
+  json_object options;
+  on_call_fn user_cb; // applies only for eInternal
+  void* user;         // applies only for eInternal
+  rpc_details() : registration_id(0), user(nullptr) {}
+};
+
+
 
 class wamp_router : public std::enable_shared_from_this<wamp_router>
 {

--- a/include/wampcc/wamp_router.h
+++ b/include/wampcc/wamp_router.h
@@ -28,6 +28,7 @@ struct rpc_details;
 /* Callback type invoked when a wamp_router has been provided with a new RPC. */
 
 typedef std::function<void(std::string, json_object)> on_rpc_registered;
+typedef std::function<void(std::string)> on_rpc_unregistered;
 
 /** Aggregate representing the details of a CALL request that has arrived at the
  * router and is to be handled via callback of user code. */
@@ -81,8 +82,8 @@ public:
     {}
   };
 
-  wamp_router(kernel* __svc, on_rpc_registered = nullptr);
   ~wamp_router();
+  wamp_router(kernel* __svc, on_rpc_registered = nullptr, on_rpc_unregistered = nullptr);
 
   /** Request asynchronous close */
   //  std::future<void> close();
@@ -118,6 +119,7 @@ private:
                            json_object&,wamp_args&);
 
   void handle_session_state_change(wamp_session&, bool);
+  void rpc_unregistered_cb(const rpc_details&);
 
   void check_has_closed();
 
@@ -138,6 +140,7 @@ private:
   std::promise<void> m_promise_on_close;
 
   on_rpc_registered m_on_rpc_registered;
+  on_rpc_unregistered m_on_rpc_unregistered;
 
   std::mutex m_server_sockets_lock;
   std::vector<std::unique_ptr<tcp_socket>> m_server_sockets;

--- a/include/wampcc/wamp_router.h
+++ b/include/wampcc/wamp_router.h
@@ -26,8 +26,8 @@ class wamp_router;
 struct rpc_details;
 
 /* Callback type invoked when a wamp_router has been provided with a new RPC. */
-typedef std::function<void(std::string)> on_rpc_registered;
 
+typedef std::function<void(std::string, json_object)> on_rpc_registered;
 
 /** Aggregate representing the details of a CALL request that has arrived at the
  * router and is to be handled via callback of user code. */

--- a/include/wampcc/wamp_session.h
+++ b/include/wampcc/wamp_session.h
@@ -126,7 +126,8 @@ struct auth_provider
                             const std::string& realm)> user_role;
 
   /* Check if the given realm, role, uri triple is allowed */
-  std::function<authorized(const std::string& realm,
+  std::function<authorized(const wampcc::t_session_id& session_id,
+                const std::string& realm,
                 const std::string& authrole,
                 const std::string& uri,
                 action)> authorize;

--- a/include/wampcc/wamp_session.h
+++ b/include/wampcc/wamp_session.h
@@ -63,6 +63,7 @@ struct auth_provider
 
   struct authorized {
     bool allow;       /* whether the action is authorized */
+    std::string reason; /* reason if authorisation denied */
     disclosure disclose;    /* whether caller/publisher identity should be disclosed */
   };
 

--- a/include/wampcc/wamp_session.h
+++ b/include/wampcc/wamp_session.h
@@ -387,13 +387,13 @@ class wamp_error : public std::runtime_error
 {
 public:
   wamp_error(const std::string& error_uri, wamp_args wa = wamp_args())
-    : std::runtime_error(error_uri),
-      m_uri(error_uri),
-      m_args(wa)
-  {  }
+      :wamp_error(error_uri.c_str(), wa) {}
+
+  wamp_error(const std::string& error_uri, const std::string& what, wamp_args wa = wamp_args())
+      :wamp_error(error_uri.c_str(), what.c_str(), wa) {}
 
   wamp_error(const char* error_uri, const char* what, wamp_args wa = wamp_args())
-    : std::runtime_error( std::string(error_uri).append(": ").append(what) ),
+    : std::runtime_error(std::string(error_uri).append(": ").append(what) ),
       m_uri(error_uri),
       m_args(wa)
   {  m_details[WAMP_ERROR_REASON_KEY] = what; }

--- a/include/wampcc/wamp_session.h
+++ b/include/wampcc/wamp_session.h
@@ -392,10 +392,10 @@ public:
   {  }
 
   wamp_error(const char* error_uri, const char* what, wamp_args wa = wamp_args())
-    : std::runtime_error(what),
+    : std::runtime_error( std::string(error_uri).append(": ").append(what) ),
       m_uri(error_uri),
       m_args(wa)
-  {  }
+  {  m_details[WAMP_ERROR_REASON_KEY] = what; }
 
   wamp_error(const char* error_uri, wamp_args wa = wamp_args())
     : std::runtime_error(error_uri),
@@ -405,12 +405,13 @@ public:
 
   wamp_args& args() { return m_args; }
   const wamp_args& args() const { return m_args; }
-
+  const json_object& details() const {return m_details;}
   const std::string & error_uri() const { return m_uri; }
 
 private:
   std::string m_uri;
   wamp_args m_args;
+  json_object m_details;
 };
 
 
@@ -956,6 +957,7 @@ private:
 
   void reply_with_error(msg_type request_type,
                         t_request_id request_id,
+                        json_object details,
                         wamp_args args,
                         std::string error_uri);
 

--- a/include/wampcc/wamp_session.h
+++ b/include/wampcc/wamp_session.h
@@ -576,6 +576,11 @@ public:
    * publishing to topics. */
   bool is_open() const;
 
+  /** Determine if the session was WELCOMEd. This returns true if
+   * WELCOME message was sent to the client. Indicates thay the client
+   * has fully joined. */
+  bool is_welcome() const;
+
   /** Determine if this session is in the closed state.  The closed state
    * implies the underlying network transport has closed, the logical-session
    * has ended, and that this instance will make no further callbacks into
@@ -1011,6 +1016,9 @@ private:
   std::unique_ptr<protocol> m_proto;
 
   std::promise< void > m_promise_on_open;
+
+  /* Track if session has been WELCOMEd. */
+  bool m_is_welcome = false;
 
   options m_options;
 

--- a/libs/wampcc/rpc_man.cc
+++ b/libs/wampcc/rpc_man.cc
@@ -56,12 +56,13 @@ uint64_t rpc_man::register_internal_rpc(const std::string& realm,
 
 
 void rpc_man::handle_inbound_register(wamp_session& ws, t_request_id request_id,
-                                      const std::string& ___uri) {
+                                      const std::string& ___uri,  const json_object& options) {
   /* EV thread */
 
   rpc_details r;
   r.registration_id = 0;
   r.uri = std::move(___uri);
+  r.options = std::move(options);
   r.session = ws.handle();
   r.type = rpc_details::eRemote;
 

--- a/libs/wampcc/rpc_man.cc
+++ b/libs/wampcc/rpc_man.cc
@@ -17,8 +17,8 @@
 namespace wampcc {
 
 /* Constructor */
-rpc_man::rpc_man(kernel* k, rpc_added_cb cb)
-  : __logger(k->get_logger()), m_rpc_added_cb(cb), m_next_regid(1) {}
+rpc_man::rpc_man(kernel* k, rpc_added_cb added_cb, rpc_removed_cb removed_cb)
+  : __logger(k->get_logger()), m_rpc_added_cb(added_cb), m_rpc_removed_cb(removed_cb), m_next_regid(1) {}
 
 rpc_details rpc_man::get_rpc_details(const std::string& rpcname,
                                      const std::string& realm) {
@@ -121,6 +121,10 @@ void rpc_man::session_closed(std::shared_ptr<wamp_session>& session) {
                  << rpc_item.second->registration_id << ", " << session->realm()
                  << "::" << rpc_item.second->uri);
 
+        /* Perform user-defined call-back, if present. */
+        if (m_rpc_removed_cb)
+            m_rpc_removed_cb(*(rpc_item.second));
+
         /* remove from realm index */
         rpcs_for_realm.erase(rpc_item.second->uri);
       }
@@ -146,6 +150,10 @@ void rpc_man::handle_inbound_unregister(wamp_session& session,
       LOG_INFO("procedure unregistered, " //
                << rpc_iter->second->registration_id << ", " << session.realm()
                << "::" << rpc_iter->second->uri);
+
+      /* Perform user-defined call-back, if present. */
+      if (m_rpc_removed_cb)
+          m_rpc_removed_cb(*(rpc_iter->second));
 
       /* remove from realm index */
       auto realm_iter = m_realm_registry.find(session.realm());

--- a/libs/wampcc/rpc_man.cc
+++ b/libs/wampcc/rpc_man.cc
@@ -63,6 +63,7 @@ void rpc_man::handle_inbound_register(wamp_session& ws, t_request_id request_id,
   r.registration_id = 0;
   r.uri = std::move(___uri);
   r.options = std::move(options);
+  r.realm = ws.realm();
   r.session = ws.handle();
   r.type = rpc_details::eRemote;
 

--- a/libs/wampcc/rpc_man.cc
+++ b/libs/wampcc/rpc_man.cc
@@ -45,6 +45,7 @@ uint64_t rpc_man::register_internal_rpc(const std::string& realm,
   r.user_cb = std::move(fn);
   r.user = user;
   r.type = rpc_details::eInternal;
+  r.realm = realm;
 
   register_rpc(session_handle(), realm, r);
 

--- a/libs/wampcc/wamp_router.cc
+++ b/libs/wampcc/wamp_router.cc
@@ -114,7 +114,7 @@ void wamp_router::rpc_registered_cb(const rpc_details& r)
 {
   std::lock_guard<std::recursive_mutex> guard(m_lock);
   if (m_on_rpc_registered)
-    m_on_rpc_registered(r.uri);
+    m_on_rpc_registered(r.uri, r.options);
 }
 
 
@@ -387,7 +387,7 @@ std::future<uverr> wamp_router::listen(auth_provider auth,
       if( !authorization.allow )
         throw wamp_error(WAMP_ERROR_NOT_AUTHORIZED, "register is not authorized");
 
-      m_rpcman->handle_inbound_register(ws, request_id, uri);
+      m_rpcman->handle_inbound_register(ws, request_id, uri, options);
     };
 
     handlers.on_unregister = [this](wamp_session& ws,

--- a/libs/wampcc/wamp_router.cc
+++ b/libs/wampcc/wamp_router.cc
@@ -233,7 +233,7 @@ void wamp_router::handle_inbound_call(
       throw wamp_error(WAMP_ERROR_NO_SUCH_PROCEDURE);
     }
   } catch (wampcc::wamp_error& ex) {
-    ws->call_error(request_id, ex.what(), ex.args().args_list, ex.args().args_dict);
+    ws->call_error(request_id, ex.error_uri(), ex.details(), ex.args().args_list, ex.args().args_dict);
   } catch (std::exception& ex) {
     ws->call_error(request_id, ex.what());
   } catch (...) {
@@ -369,7 +369,7 @@ std::future<uverr> wamp_router::listen(auth_provider auth,
           ws.published(request_id, publication_id);
       }
       catch (const wamp_error& e) {
-        ws.publish_error(request_id, e.error_uri());
+        ws.publish_error(request_id, e.error_uri(), e.details());
       }
     };
 

--- a/libs/wampcc/wamp_router.cc
+++ b/libs/wampcc/wamp_router.cc
@@ -146,7 +146,7 @@ void wamp_router::handle_inbound_call(
     auto authorization = ws->authorize(uri, auth_provider::action::call);
 
     if( !authorization.allow )
-      throw wamp_error(WAMP_ERROR_NOT_AUTHORIZED, "call is not authorized");
+      throw wamp_error(WAMP_ERROR_NOT_AUTHORIZED, authorization.reason.c_str() );
 
     json_object details;
 

--- a/libs/wampcc/wamp_session.cc
+++ b/libs/wampcc/wamp_session.cc
@@ -2829,7 +2829,7 @@ auth_provider::authorized wamp_session::authorize(const std::string& uri, auth_p
         realm = m_realm;
         authrole = m_authrole;
       }
-      authorized = m_auth_proivder.authorize(realm, authrole, uri, action);
+      authorized = m_auth_proivder.authorize(this->unique_id(), realm, authrole, uri,  action);
     } catch(...) {
       throw wamp_error(WAMP_ERROR_AUTHORIZATION_FAILED, "authorization failure");
     }

--- a/libs/wampcc/wamp_session.cc
+++ b/libs/wampcc/wamp_session.cc
@@ -2831,6 +2831,8 @@ auth_provider::authorized wamp_session::authorize(const std::string& uri, auth_p
         authrole = m_authrole;
       }
       authorized = m_auth_proivder.authorize(this->unique_id(), realm, authrole, uri,  action);
+    } catch(const wampcc::wamp_error&) {
+          throw;
     } catch(...) {
       throw wamp_error(WAMP_ERROR_AUTHORIZATION_FAILED, "authorization failure");
     }

--- a/libs/wampcc/wamp_session.cc
+++ b/libs/wampcc/wamp_session.cc
@@ -1423,7 +1423,7 @@ void wamp_session::process_inbound_invocation(json_array & msg)
   }
   catch (wampcc::wamp_error& ex)
   {
-    reply_with_error(msg_type::wamp_msg_invocation, request_id, ex.args(), ex.error_uri());
+    reply_with_error(msg_type::wamp_msg_invocation, request_id, ex.details(), ex.args(), ex.error_uri());
   }
 }
 
@@ -2114,7 +2114,7 @@ void wamp_session::process_inbound_call(json_array & msg)
   }
   catch(wamp_error& ex)
   {
-    reply_with_error(msg_type::wamp_msg_call, request_id, ex.args(), ex.error_uri());
+    reply_with_error(msg_type::wamp_msg_call, request_id, ex.details(), ex.args(), ex.error_uri());
   }
 }
 
@@ -2223,7 +2223,7 @@ void wamp_session::process_inbound_publish(json_array & msg)
   }
   catch(wamp_error& ex)
   {
-    reply_with_error(msg_type::wamp_msg_publish, request_id, ex.args(), ex.error_uri());
+    reply_with_error(msg_type::wamp_msg_publish, request_id, ex.details(), ex.args(), ex.error_uri());
   }
 }
 
@@ -2250,7 +2250,7 @@ void wamp_session::process_inbound_subscribe(json_array & msg)
   }
   catch(wamp_error& ex)
   {
-    reply_with_error(msg_type::wamp_msg_subscribe, request_id, ex.args(), ex.error_uri());
+    reply_with_error(msg_type::wamp_msg_subscribe, request_id, ex.details(), ex.args(), ex.error_uri());
   }
 }
 
@@ -2273,7 +2273,7 @@ void wamp_session::process_inbound_unsubscribe(json_array & msg)
   }
   catch(wamp_error& ex)
   {
-    reply_with_error(msg_type::wamp_msg_unsubscribe, request_id, ex.args(), ex.error_uri());
+    reply_with_error(msg_type::wamp_msg_unsubscribe, request_id, ex.details(), ex.args(), ex.error_uri());
   }
 }
 
@@ -2301,17 +2301,18 @@ void wamp_session::process_inbound_register(json_array & msg)
   }
   catch(wamp_error& ex)
   {
-    reply_with_error(msg_type::wamp_msg_register, request_id, ex.args(), ex.error_uri());
+    reply_with_error(msg_type::wamp_msg_register, request_id, ex.details(), ex.args(), ex.error_uri());
   }
 }
 
 void wamp_session::reply_with_error(
   msg_type request_type,
   t_request_id request_id,
+  json_object details,
   wamp_args args,
   std::string error_uri)
 {
-  json_array msg {msg_type::wamp_msg_error, request_type, request_id, json_object(),
+  json_array msg {msg_type::wamp_msg_error, request_type, request_id, details,
       error_uri, args.args_list, args.args_dict};
   send_msg(msg);
 }
@@ -2810,7 +2811,7 @@ auth_provider::authorized wamp_session::authorize(const std::string& uri, auth_p
 {
   /* Default behaviour is to authorize every call and not to disclose
    * caller and publisher idetity */
-  auth_provider::authorized authorized = {true, auth_provider::disclosure::optional};
+  auth_provider::authorized authorized = {true, "", auth_provider::disclosure::optional};
   if(m_auth_proivder.authorize) {
     try {
       /* Note, we are holding a lock across user callback here. Typically
@@ -2940,7 +2941,7 @@ void wamp_session::process_inbound_unregister(json_array & msg)
     m_server_handler.on_unregister(*this, request_id, registration_id);
   }
   catch (wamp_error& ex) {
-    reply_with_error(msg_type::wamp_msg_unregister, request_id, ex.args(), ex.error_uri());
+    reply_with_error(msg_type::wamp_msg_unregister, request_id, ex.details(), ex.args(), ex.error_uri());
   }
 }
 

--- a/libs/wampcc/wamp_session.cc
+++ b/libs/wampcc/wamp_session.cc
@@ -1118,6 +1118,11 @@ void wamp_session::send_WELCOME()
 
   send_msg( msg );
 
+  {
+      std::lock_guard<std::mutex> guard(m_state_lock);
+      m_is_welcome = true;
+  }
+
   if (is_open())
     notify_session_open();
 }
@@ -1141,6 +1146,12 @@ bool wamp_session::is_open() const
 {
   std::lock_guard<std::mutex> guard(m_state_lock);
   return m_state == state::open;
+}
+
+bool wamp_session::is_welcome() const
+{
+    std::lock_guard<std::mutex> guard(m_state_lock);
+    return m_is_welcome;
 }
 
 bool wamp_session::is_closed() const


### PR DESCRIPTION
This pull request improves wampcc and makes its error handling WAMP-specification compliant.

Improvements:

- Add option for listening on IPv6 only 
- Pass  the session ID to authorization provider when authorizing an action 
- Pass WAMP `Options` dict when handling an RPC REGISTER event
- Add callback for when an RPC is unregistered
- Pass the realm name when calling the RPC registration callback
- Add realm name  to `rpc_details` struct
- Move definition of `rpc_details` to `wamp_router.h`, as it its needed using by RPC registration callbacks

Presently, when an exception is raised with a message, for example:

https://github.com/darrenjs/wampcc/blob/066439f17c4e8977c348d74867b9a3492ce08572/libs/wampcc/wamp_router.cc#L138

then, depending on how the exception is caught, the second part of the exception message (e.g. "call is not authorized" above) is used as the error URI when the error is transmitted. This is in violation of the WAMP specification. 

This pull request ensures that the error URI is always used. If there is an exception message then it is placed inside a "_reason" field in the WAMP error `Details` dict.
