### PR TITLE
Fix memory leak in ssl_context

### DIFF
--- a/include/wampcc/ssl.h
+++ b/include/wampcc/ssl.h
@@ -27,6 +27,7 @@ class ssl_context
 {
 public:
   ssl_context(logger &, const ssl_config& conf);
+  ~ssl_context();
 
   /* log all entries in the SSL error queue */
   void log_ssl_error_queue();

--- a/libs/wampcc/ssl.cc
+++ b/libs/wampcc/ssl.cc
@@ -88,6 +88,10 @@ ssl_context::ssl_context(logger & l,
   }
 }
 
+ssl_context::~ssl_context() {
+    if (m_ctx)
+      SSL_CTX_free(m_ctx);
+}
 
 void ssl_context::log_ssl_error_queue()
 {


### PR DESCRIPTION
This pull request fixes a memory leak in ssl_context, by ensuring that that `SSL_CTX_free()` function is called in the destructor.

Without this, there is a memory leak on when using `wampcc` as an SSL WAMP
client, as shown below:

```
$ /utils/admin lcoalhost 8080 --proto web,ssl -c wamp.reflection.procedure.list

...

=================================================================
==10420==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1024 byte(s) in 1 object(s) allocated from:
    #0 0x4eb9f3 in __interceptor_malloc (/home/saman/work/ucss/wampcc/build/utils/admin+0x4eb9f3)
    #1 0x7fb76e619328 in CRYPTO_zalloc (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x192328)

Indirect leak of 1728 byte(s) in 19 object(s) allocated from:
    #0 0x4eb9f3 in __interceptor_malloc (/home/saman/work/ucss/wampcc/build/utils/admin+0x4eb9f3)
    #1 0x7fb76e619328 in CRYPTO_zalloc (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x192328)

Indirect leak of 504 byte(s) in 1 object(s) allocated from:
    #0 0x4ebe12 in realloc (/home/saman/work/ucss/wampcc/build/utils/admin+0x4ebe12)
    #1 0x7fb76e67a1a4  (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x1f31a4)

Indirect leak of 504 byte(s) in 1 object(s) allocated from:
    #0 0x4eb9f3 in __interceptor_malloc (/home/saman/work/ucss/wampcc/build/utils/admin+0x4eb9f3)
    #1 0x7fb76e67a758 in OPENSSL_sk_dup (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x1f3758)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x4eb9f3 in __interceptor_malloc (/home/saman/work/ucss/wampcc/build/utils/admin+0x4eb9f3)
    #1 0x7fb76e67a6fe in OPENSSL_sk_dup (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x1f36fe)

SUMMARY: AddressSanitizer: 3792 byte(s) leaked in 23 allocation(s).

```