### PR TITLE
Fixed memory leak in do_write function

### DIFF
--- a/libs/wampcc/tcp_socket.cc
+++ b/libs/wampcc/tcp_socket.cc
@@ -538,10 +538,9 @@ void tcp_socket::do_write(std::vector<uv_buf_t>& bufs)
       tcp_socket* the_tcp_socket = (tcp_socket*)req->data;
       the_tcp_socket->on_write_cb(req, status);
     });
+    buf_guard.dismiss();
 
-    if (r == 0)
-      buf_guard.dismiss(); /* bufs will be deleted in uv callback */
-    else {
+    if( r ) {
       LOG_WARN("uv_write failed, errno " << std::abs(r) << " ("
                                          << uv_strerror(r)
                                          << "); closing connection");
@@ -601,10 +600,9 @@ void tcp_socket::do_write()
       tcp_socket* the_tcp_socket = (tcp_socket*)req->data;
       the_tcp_socket->on_write_cb(req, status);
     });
+    buf_guard.dismiss();
 
-    if (r == 0)
-      buf_guard.dismiss(); /* bufs will be deleted in uv callback */
-    else {
+    if( r ) {
       LOG_WARN("uv_write failed, errno " << std::abs(r) << " ("
                                          << uv_strerror(r)
                                          << "); closing connection");

--- a/libs/wampcc/tcp_socket.cc
+++ b/libs/wampcc/tcp_socket.cc
@@ -543,6 +543,11 @@ void tcp_socket::do_write(std::vector<uv_buf_t>& bufs)
       return;
     };
   }
+  else
+  {
+    for (size_t i = 0; i < bufs.size(); i++)
+      delete[] bufs[i].base;
+  }
 }
 
 void tcp_socket::do_write()


### PR DESCRIPTION
Memory leak occurs when connection lost and `do_write` function is called.

```
==2272== 66 bytes in 2 blocks are definitely lost in loss record 222 of 412
==2272==    at 0x4C298A0: operator new[](unsigned long) (vg_replace_malloc.c:389)
==2272==    by 0x44465B88: wampcc::ssl_socket::write_encrypted_bytes(char const*, unsigned long) (ssl_socket.cc:244)
==2272==    by 0x4446540E: wampcc::ssl_socket::do_encrypt_and_write(char*, unsigned long) (ssl_socket.cc:169)
==2272==    by 0x44464EA8: wampcc::ssl_socket::service_pending_write() (ssl_socket.cc:104)
==2272==    by 0x4446E37A: wampcc::tcp_socket::write(std::pair<char const*, unsigned long>*, unsigned long)::{lambda()#2}::operator()() const (tcp_socket.cc:500)
==2272==    by 0x44473366: std::_Function_handler<void (), wampcc::tcp_socket::write(std::pair<char const*, unsigned long>*, unsigned long)::{lambda()#2}>::_M_invoke(std::_Any_data const&) (std_function.h:316)
==2272==    by 0x44418ADD: std::function<void ()>::operator()() const (std_function.h:706)
==2272==    by 0x44445C88: wampcc::io_loop::on_async() (io_loop.cc:136)
==2272==    by 0x4444544A: wampcc::io_loop::io_loop(wampcc::kernel&, std::function<void ()>)::{lambda(uv_async_s*)#1}::operator()(uv_async_s*) const (io_loop.cc:64)
==2272==    by 0x4444546A: wampcc::io_loop::io_loop(wampcc::kernel&, std::function<void ()>)::{lambda(uv_async_s*)#1}::_FUN(uv_async_s*) (io_loop.cc:65)
==2272==    by 0x3C49AF1B: uv__async_io (async.c:118)
==2272==    by 0x3C4B0411: uv__io_poll (linux-core.c:375)
```