### PR TITLE
router: Fix forwarding of error details.

### DIFF
--- a/libs/wampcc/wamp_router.cc
+++ b/libs/wampcc/wamp_router.cc
@@ -211,7 +211,7 @@ void wamp_router::handle_inbound_call(
                 if (info)
                   caller->result(caller_request_id, info.args.args_list, info.args.args_dict);
                 else
-                  caller->call_error(caller_request_id, info.error_uri, info.args.args_list, info.args.args_dict);
+                  caller->call_error(caller_request_id, info.error_uri, info.additional, info.args.args_list, info.args.args_dict);
               }
             };
 


### PR DESCRIPTION
* wamp_router should forward any additional error details received
  from an INVOCATION request back to the original caller.