### PR TITLE
include/wampcc/platform.h: fix build with musl 1.2.0

### DIFF
--- a/include/wampcc/platform.h
+++ b/include/wampcc/platform.h
@@ -27,7 +27,7 @@ namespace wampcc
   struct time_val
   {
 #ifndef _WIN32
-    typedef long type_type;
+    typedef time_t type_type;
 #else
     typedef __time64_t type_type;
 #endif


### PR DESCRIPTION
Fix the following build failure on musl 1.2.0 due to time_t being on 64 bits:

```
/home/naourr/work/instance-0/output-1/build/wampcc-1.6/libs/wampcc/utils.cc: In function 'std::__cxx11::string wampcc::local_timestamp()':
/home/naourr/work/instance-0/output-1/build/wampcc-1.6/libs/wampcc/utils.cc:205:15: error: cannot convert 'wampcc::time_val::type_type*' {aka 'long int*'} to 'const time_t*' {aka 'const long long int*'}
   localtime_r(&now.sec, &parts);
               ^~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/da996e189220499b85efbdb541a891ac18db38c6

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>