### PR TITLE
router: Add support for querying listen addresses.

### DIFF
--- a/include/wampcc/socket_address.h
+++ b/include/wampcc/socket_address.h
@@ -46,6 +46,9 @@ public:
   /** String representation of the address. */
   std::string to_string() const;
 
+  /** Return the local port. */
+  int port() const;
+
   void swap(socket_address&);
 
 private:

--- a/include/wampcc/wamp_router.h
+++ b/include/wampcc/wamp_router.h
@@ -136,6 +136,10 @@ public:
                 on_call_fn,
                 void * user = nullptr);
 
+
+  /** Return list of addresses the router is currently listening on. */
+  std::vector<socket_address> get_listen_addresses() const;
+
 private:
   void rpc_registered_cb(const rpc_details&);
   void handle_inbound_call(wamp_session*,t_request_id,std::string&,
@@ -166,7 +170,7 @@ private:
   on_rpc_unregistered m_on_rpc_unregistered;
   on_session_state_change m_on_session_state_change;
 
-  std::mutex m_server_sockets_lock;
+  mutable std::mutex m_server_sockets_lock;
   std::vector<std::unique_ptr<tcp_socket>> m_server_sockets;
 };
 

--- a/libs/wampcc/socket_address.cc
+++ b/libs/wampcc/socket_address.cc
@@ -102,5 +102,24 @@ std::string socket_address::to_string() const
   return text;
 }
 
+int socket_address::port() const
+{
+  ::sockaddr_storage* ss = m_impl.get();
+  if (ss == nullptr)
+    return 0;
+
+  if (ss->ss_family == AF_INET) {
+    auto* addrin = (::sockaddr_in *) ss;
+    return ntohs(addrin->sin_port);
+  }
+
+  if (ss->ss_family == AF_INET6) {
+    auto* addrin6 = (::sockaddr_in6 *) ss;
+    return ntohs(addrin6->sin6_port);
+  }
+
+  return 0;
+}
+
 
 } // namespace wampcc

--- a/libs/wampcc/wamp_router.cc
+++ b/libs/wampcc/wamp_router.cc
@@ -14,6 +14,7 @@
 #include "wampcc/io_loop.h"
 #include "wampcc/ssl_socket.h"
 #include "wampcc/tcp_socket.h"
+#include "wampcc/socket_address.h"
 #include "wampcc/log_macros.h"
 #include "wampcc/protocol.h"
 
@@ -492,6 +493,20 @@ std::future<uverr> wamp_router::listen(auth_provider auth,
       listen_opts.af);
 
   return fut;
+}
+
+std::vector<socket_address> wamp_router::get_listen_addresses() const
+{
+  std::vector<socket_address> ret;
+  {
+    std::lock_guard<std::mutex> guard(m_server_sockets_lock);
+    for (const auto& s : m_server_sockets)
+    {
+      if (s->is_listening())
+        ret.emplace_back(s->get_local_address());
+    }
+  }
+  return ret;
 }
 
 } // namespace


### PR DESCRIPTION
wampcc::tcp_socket and therefore wampcc::router::listen() allows for binding to a currently free port by passing "0" as the port number, which is sometimes very useful (e.g. example during testing). However, wampcc::router currently does not provide an API to query the port that was picked. 
This commit adds such an API and to this end also extends wampcc::socket_address with a `port() ` function.

Alternatively, one could extend the return value of `wampcc::tcp_socket::listen()` but this seems to require a larger refactoring. 
