### PR TITLE
Fix getting the thread ID on macOS systems

### DIFF
--- a/libs/wampcc/platform.cc
+++ b/libs/wampcc/platform.cc
@@ -23,18 +23,25 @@
 #endif
 #endif
 
+#ifdef __APPLE__
+#include <pthread.h> /* For pthread_threadid_np() */
+#endif
+
 namespace wampcc
 {
 
-int thread_id()
-{
-#ifndef _WIN32
-  /* On Linux the thread-id returned via syscall is more useful than that C++
-   * get_id(), since it will correspond to the values reported by top and other
+int thread_id() {
+  /* It's more useful to return the kernel thread ID than the C++ get_id(),
+   * since it will correspond to the values reported by top and other
    * tools. */
-  return syscall(SYS_gettid);
-#else
+#ifdef __APPLE__
+  uint64_t tid;
+  pthread_threadid_np(NULL, &tid);
+  return tid;
+#elif _WIN32
   return GetCurrentThreadId();
+#else
+  return syscall(SYS_gettid);
 #endif
 }
 


### PR DESCRIPTION
Currently, on non-Windows systems we do a `syscall(SYS_gettid)` to get the thread ID. However, this is Linux-only and doesn't work on macOS (i.e. the syscall will always return `-1`). On macOS the correct syscall to use would be `SYS_thread_selfid`.

In any case, making system calls has been deprecated since macOS 10.12, and will result in warnings like so:

```
wampcc/platform.cc:35:10: warning: 'syscall' is deprecated: first deprecated in macOS
      10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost().
      [-Wdeprecated-declarations]
  return syscall(SYS_gettid);
         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
int      syscall(int, ...);
         ^
1 warning generated.
```

This commit fixes it by using the Apple-specific `pthread_threadid_np()` function instead. This function returns the same thread ID as the system call.

Technically we should also change the return type of the function for each OS (i.e. `DWORD` for Windows, `pid_t` for Linux, `uint64_t` for Apple).

Note also that on macOS you don't have to link against `pthread`, so all good there.