### PR TITLE
Link examples and utils against pthreads on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,16 @@ set(HAVE_LIBUV ON)
 find_package(Jansson REQUIRED)
 set(HAVE_JANSSON ON)
 
+##
+## Find Threads on Linux systems, for compiling EXAMPLES or UTILS
+##
+
+if(CMAKE_HOST_UNIX)
+  if (BUILD_EXAMPLES OR BUILD_UTILS)
+    find_package(Threads REQUIRED)
+  endif()
+endif()
+
 message(STATUS "OpenSSL_INCLUDE_DIR:      " ${OPENSSL_INCLUDE_DIR})
 message(STATUS "OpenSSL_LIBRARIES:        " ${OPENSSL_LIBRARIES})
 message(STATUS "LibUV_INCLUDE_DIRS:       " ${LibUV_INCLUDE_DIRS})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,6 +4,12 @@ else()
   set(EXTRA_LIBS wampcc_static wampcc_json_static)
 endif()
 
+# Needed because std::condition_variable::wait_for() on libstdc++
+# uses pthreads.
+if(CMAKE_HOST_UNIX)
+  set(EXTRA_LIBS ${EXTRA_LIBS} Threads::Threads)
+endif()
+
 # Helper macro for example compilation
 macro(Compile_Example example source_path)
   add_executable(${example} "${PROJECT_SOURCE_DIR}/examples/${source_path}/${example}.cc")

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -4,6 +4,12 @@ else()
   set(EXTRA_LIBS ${EXTRA_LIBS} wampcc_static wampcc_json_static)
 endif()
 
+# Needed because std::condition_variable::wait_for() on libstdc++
+# uses pthreads.
+if(CMAKE_HOST_UNIX)
+  set(EXTRA_LIBS ${EXTRA_LIBS} Threads::Threads)
+endif()
+
 if(BUILD_UTILS)
 
   add_executable(admin "${PROJECT_SOURCE_DIR}/utils/admin.cc")


### PR DESCRIPTION
Compiling the examples and admin utility included in wampcc on recent Linux  distributions results in a number of linking errors, such as:

```
[ 55%] Linking CXX executable admin
/usr/bin/ld: CMakeFiles/admin.dir/admin.cc.o: undefined reference to symbol 'pthread_cond_clockwait@@GLIBC_2.30'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
```

and so on.

This is because in some versions of libstdc++ (at least on 10.2.1), `std::condition_variable::wait_for()` is implemented using `__gthread_cond_wait()` and in turn `pthread_cond_clockwait()`, see [here for the relevant section in libstdc++](https://github.com/gcc-mirror/gcc/blob/releases/gcc-8/libstdc++-v3/src/c++11/condition_variable.cc#L53). So one needs to link against pthreads.

Although this linking was always required, in previous version of libstdc++ there was a bug: if pthreads was not linked against then there was no error message but `std::condition_variable::wait_for()` would immediately return.

This merge request fixes this by linking the examples and utils against pthreads on Linux systems.