### PR TITLE
Export custom `Find<Package>.cmake` recipes when exporting config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,12 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/wampccConfig.cmake"
         DESTINATION ${INSTALL_CMAKE_DIR}
         COMPONENT dev)
 
+# Export any custom "Find<PackageName>.cmake" files
+FILE(GLOB CUSTOM_MODULE_FIND_FILES "${CMAKE_CURRENT_LIST_DIR}/cmake/Find*.cmake")
+install(FILES ${CUSTOM_MODULE_FIND_FILES}
+        DESTINATION ${INSTALL_CMAKE_DIR}/find_modules
+        COMPONENT dev)
+
 get_property(EXPORT_TARGETS GLOBAL PROPERTY WAMPCC_INSTALL_TARGETS)
 install(EXPORT wampccExportTargets
         FILE wampccTargets.cmake

--- a/cmake/wampccConfig.cmake.in
+++ b/cmake/wampccConfig.cmake.in
@@ -2,7 +2,24 @@
 
 include(CMakeFindDependencyMacro)
 
+# Some dependenciess (UV and Jansson) don't usually come with a CMake
+# find module, so distribute ours.
+
+# Set module path
+set(wampcc_original_module_path "${CMAKE_MODULE_PATH}")
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/find_modules")
+
+# Import modules
+find_dependency(OpenSSL REQUIRED)
+find_dependency(LibUV REQUIRED)
+find_dependency(Jansson REQUIRED)
+if(CMAKE_HOST_UNIX)
+  find_dependency(Threads REQUIRED)
+endif()
+
+# Restore old path
+set(CMAKE_MODULE_PATH "${wampcc_original_module_path}")
+unset(wampcc_original_module_path)
+
 # Add the targets file
 include("${CMAKE_CURRENT_LIST_DIR}/wampccTargets.cmake")
-
-


### PR DESCRIPTION
On most systems Jansson and UV don't come with a `Find<PackageName>.cmake` or `<PackageName>Config.cmake` files, so in wampcc we are using custom find module recipes to find Jansson and UV.

However, at the moment these custom find recipes are not exported during a cmake install. This commit causes these custom find recipes to also be exported as part of an install. This way UV and Jansson are automatically found when a user does `find_package(wampcc)` in a CMake recipe.