### PR TITLE
Link wampcc against pthreads on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,9 +93,7 @@ set(HAVE_JANSSON ON)
 ##
 
 if(CMAKE_HOST_UNIX)
-  if (BUILD_EXAMPLES OR BUILD_UTILS)
-    find_package(Threads REQUIRED)
-  endif()
+  find_package(Threads REQUIRED)
 endif()
 
 message(STATUS "OpenSSL_INCLUDE_DIR:      " ${OPENSSL_INCLUDE_DIR})

--- a/libs/wampcc/CMakeLists.txt
+++ b/libs/wampcc/CMakeLists.txt
@@ -44,6 +44,7 @@ if(BUILD_STATIC_LIBS)
       PRIVATE
 	    LibUV::LibUV
 	    OpenSSL::SSL
+        Threads::Threads
 	  PUBLIC
 		wampcc_json_static)
 
@@ -77,6 +78,7 @@ if(BUILD_SHARED_LIBS)
       PRIVATE
 	    LibUV::LibUV
 	    OpenSSL::SSL
+        Threads::Threads
 	  PUBLIC
 		wampcc_json_shared)
   add_dependencies(wampcc_shared wampcc_json_shared)


### PR DESCRIPTION
When using the version version of wampcc in Linux (but not on Windows), I came across this error:

```
[ 50%] Building CXX object router/CMakeFiles/router.dir/src/main.cpp.o
[100%] Linking CXX executable router
/usr/lib/gcc/x86_64-nilrt-linux/10.3.0/../../../../x86_64-nilrt-linux/bin/ld: /opt/wampcc/lib64/libwampcc.a(event_loop.cc.o): undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/lib/gcc/x86_64-nilrt-linux/10.3.0/../../../../x86_64-nilrt-linux/bin/ld: /lib64/libpthread.so.0: error adding symbols: DSO missing from command line
```

It looks like something in  `even_loop.cc` has a direct or indirect dependency on `pthreads`. I suspect that this was always there, but in previous version of libstdc++ there was a bug: if pthread was not linked against then there was no error message sometimes (see pull request #74).

This pull request links agasinst `pthreads` on Linux/Unix and solved the above error.