### PR TITLE
CMake: Adjust BUILD_TESTS config.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -32,6 +32,7 @@ if(BUILD_EXAMPLES)
   Compile_Example(basic_callee_ssl basic)
   Compile_Example(demo_embedded_router_ssl basic)
   Compile_Example(demo_embedded_router basic)
+  Compile_Example(demo_client basic)
   Compile_Example(basic_server basic)
 # Authentication
   Compile_Example(basic_authentication_provider authentication)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,15 +8,35 @@ list(APPEND EXTRA_LIBS ${LIBUV_LIBRARIES} ${OPENSSL_LIBRARIES} ${JANSSON_LIBRARI
 
 if(BUILD_TESTS)
 
-  add_executable(test_misc
-    "${PROJECT_SOURCE_DIR}/tests/test_misc.cc"
-    "${PROJECT_SOURCE_DIR}/tests/test_common.h" )
-  target_link_libraries(test_misc ${EXTRA_LIBS})
+  # Helper macro for test compilation
+  macro(Compile_Test TEST_NAME)
+    add_executable(${TEST_NAME}
+        "${PROJECT_SOURCE_DIR}/tests/wampcc/${TEST_NAME}.cc"
+        "${PROJECT_SOURCE_DIR}/tests/wampcc/test_common.h" )
+    target_link_libraries(${TEST_NAME} ${EXTRA_LIBS})
+    target_include_directories(${TEST_NAME} PRIVATE "${PROJECT_SOURCE_DIR}")
+    if (WIN32)
+      set_target_properties(${TEST_NAME} PROPERTIES LINK_FLAGS "/NODEFAULTLIB:libcmt.lib /NODEFAULTLIB:libcmtd.lib")
+    endif()
+  endmacro()
 
-  if (WIN32)
-    set_target_properties(test_misc PROPERTIES LINK_FLAGS "/NODEFAULTLIB:libcmt.lib /NODEFAULTLIB:libcmtd.lib")
-  endif()
-
+  Compile_Test(test_basic_codecs)
+  Compile_Test(test_connect_timeout)
+  Compile_Test(test_early_wamp_session_destructor)
+  Compile_Test(test_evthread_wamp_session_destructor)
+  Compile_Test(test_late_dealer_destructor)
+  Compile_Test(test_late_wamp_session_destructor)
+  Compile_Test(test_misc)
+  Compile_Test(test_register_unregister)
+  Compile_Test(test_router_functions)
+  Compile_Test(test_send_and_close)
+  Compile_Test(test_tcp_socket)
+  Compile_Test(test_tcp_socket_connect)
+  Compile_Test(test_tcp_socket_connect_cb)
+  Compile_Test(test_tcp_socket_listen)
+  Compile_Test(test_tcp_socket_passive_disconnect)
+  Compile_Test(test_wamp_rpc)
+  Compile_Test(test_wamp_session_fast_close)
 
 ##
 ## Add more test build rules here


### PR DESCRIPTION
* Fix incorrect test file location in test_misc target.
* Add Compile_Test cmake macro and use it to add build targets for all wamp tests.