### PR TITLE
catch exception in wamp_session::send_msg in case of problems with underlying socket

### DIFF
--- a/libs/wampcc/wamp_session.cc
+++ b/libs/wampcc/wamp_session.cc
@@ -781,8 +781,14 @@ void wamp_session::send_msg(const json_array& jv)
   }
 
   update_state_for_outbound(jv);
-
-  m_proto->send_msg(jv);
+  try
+  {
+    m_proto->send_msg(jv);
+  }
+  catch (...)
+  {
+    handle_exception();
+  }
 }
 
 


### PR DESCRIPTION
Catching write exception on the session it belongs to instead of propagating further (for example, to pubsub_man::update_topic) and possibly dropping the session that posted the data to the topic our problematic client is subscribed to.

Problem was observed when one slow subscriber (able to hit wampcc::default_socket_max_pending_write_bytes limit) was able to drop the sessions of all the publishers to the topics it is subscribed to.